### PR TITLE
feat: change namespace to tornado

### DIFF
--- a/deploy/manifests/dev/us-east-2/.sops.yaml
+++ b/deploy/manifests/dev/us-east-2/.sops.yaml
@@ -1,6 +1,6 @@
 creation_rules:
   - path_regex: '.+\.y(a)?ml'
     encrypted_regex: '^(data|stringData)$'
-    kms: 'arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/autoretrieve'
+    kms: 'arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/tornado'
   - path_regex: '.*'
-    kms: 'arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/autoretrieve'
+    kms: 'arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/tornado'

--- a/deploy/manifests/dev/us-east-2/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/kustomization.yaml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: autoretrieve
+namespace: tornado
 resources:
 - lassie-event-recorder
 images:
 - name: lassie-event-recorder
-  newName: ghcr.io/filecoin-project/lassie-event-recorder # {"$imagepolicy": "autoretrieve:lassie-event-recorder:name"}
-  newTag: 20230605-064348-2c27726 # {"$imagepolicy": "autoretrieve:lassie-event-recorder:tag"}
+  newName: ghcr.io/filecoin-project/lassie-event-recorder # {"$imagepolicy": "tornado:lassie-event-recorder:name"}
+  newTag: 20230605-064348-2c27726 # {"$imagepolicy": "tornado:lassie-event-recorder:tag"}

--- a/deploy/manifests/dev/us-east-2/lassie-event-recorder/basic-auth-secret.yaml
+++ b/deploy/manifests/dev/us-east-2/lassie-event-recorder/basic-auth-secret.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 stringData:
-    #ENC[AES256_GCM,data:ZuBU/LyTmEP8Blqs0tZ98Uq4SKlyZt9feyJpIZmL55aHcde8T7nZmrn0OXASEueKaIndvc40RRJZINk=,iv:+xI6MjpeT/BlRTWMK8ck3pT8ZBkEvyP1cXy2IxkRA1k=,tag:TZwMWbEqzX0ngPckmh1N+Q==,type:comment]
-    #ENC[AES256_GCM,data:il6Y+IUL6+IPIgmYkhWivOu/5VGiEbjCSPaLbkmRrVk92A++lo0B6mXjKrmxMZ4rQulP/PX+jWO/rIpNkWVzORkEMEc7nJxBR+yb+2iJzPfLDjRIqYBLfIKszc0=,iv:2vYzL/6yfGxHaEw4qZkaSgFizE8ae9an5/UyvI67YKU=,tag:kw7grp0FqwQg22izzkGfwA==,type:comment]
-    #ENC[AES256_GCM,data:FIeQs3fw,iv:noGtzjFQ/OLCMeSIwEHAzV36CSRXmT+khjO1gwrskyw=,tag:eqWcTEiq6onoegom8PeLlg==,type:comment]
-    #ENC[AES256_GCM,data:ThRPDYw9pbtSQctv/eoQ//pzRZ+fOQ1JcFke,iv:tm2VffeTa0TgTPaGUxpXeUTKICAIgj4VHlPesHn8NY8=,tag:HwBRZJT317BASGohJp2lkg==,type:comment]
-    #ENC[AES256_GCM,data:Jg==,iv:ej+ssT9fjc3W5C7K+OkwN3VElu2DVgrb+cknDZuuR8A=,tag:2O5nIN32Od3vf+uBPpO5yw==,type:comment]
-    #ENC[AES256_GCM,data:XH+eVXdUXItEqmEZOVl1vdaVDq+j0X3Y1z3iPMcxl4zT/fo8XVPHSQR4eAtgZPNA4JlK3L7ySSu0bkQaheACRvptHOob,iv:UjIo8mqwoD1kdRec26Xz2/XEkpDgumg33bc9DnWKj3U=,tag:y7Wma83I8nZMP1sIBzgu+g==,type:comment]
-    #ENC[AES256_GCM,data:0RdwDLaXOug/bdmSMu2tYy4YeNsrBFctJBX++xx4ieWA0a8k/ZjWhdSeM2rqdJHJheNX+bhCUPHUFD33gk+LyZeqXmQ=,iv:wLSst/NVMhYKAbJ47Ota3ljIlUX4W0+QfCH/3G8QSYY=,tag:uSDl3ZZsrKaPtM21026bFg==,type:comment]
+    #ENC[AES256_GCM,data:n2Fu068jJ7URww+EzH804rWnyAqduCGHoi3l+ZMrxHzv9Od6590qOvs5tCwunHqmO2wYsHzJE/OSw88=,iv:hCwd7otCQRPPTPoNkrA1huk2XWYuulvK5T4T+U3mqpY=,tag:k1vlVElS1ESx586DmhCw/g==,type:comment]
+    #ENC[AES256_GCM,data:dBhleCeVddK7b7J+Ef4s58/OUi2qg2xmkINB/ZzAJQngKqUWtVZTFWPOLrDny0Y4qgRQYGyw/5PnygVmgMHeSnCe4+mk28K91hA5OD/s0Y+dISnYD51a+w7ND7Y=,iv:DhowXUtnCLRosvXr47R4DvnEu85RfEUeMUkyZszvemI=,tag:bbKAxH5Z13oCAjnPzK3xkg==,type:comment]
+    #ENC[AES256_GCM,data:ibX0tjaa,iv:4NArJY1zi///th4xCQ6SxvtxR+ozAEpmwGmUAE+m058=,tag:Z6fyX51VEjGWlUWjF5UrjQ==,type:comment]
+    #ENC[AES256_GCM,data:AHPvxml8HRxkvrxMzswT6Mvq0LNTBIXY6GBb,iv:+d83TewV6pkbQ9vUzSH7NrrIXAmJRANeFZOuqmJQAFs=,tag:tZ9FRmPMKD1mRJRn6a5mOg==,type:comment]
+    #ENC[AES256_GCM,data:bg==,iv:E4jRN4cw0dYjyGmVeLo42Kg9j4X+4BTqjbh6sueThPE=,tag:NvbcPy+HArOncDN51jiRJA==,type:comment]
+    #ENC[AES256_GCM,data:G0/xEXYjeAg7j/FNw1vEiEiZSwc1X6hfJB5s0Cj8dycF0sq8Iz8OSU86R+nOCSpfXIb3uiFu7wUsswQQQ4WAYpxsLFyJ,iv:YCada9gg0BeZIYXaEtaZWizOCT6BwVQB2aQU9AnIoe4=,tag:QlC8MKFEnaXNJ6otNOIZmQ==,type:comment]
+    #ENC[AES256_GCM,data:mSfhnmnA5Fu6Bdx9HhD0IkMf8iET4lovabVU7puYnfXm2yq7ACKvFHQT3KX4kE70EyAtbSmFNkJ8HFxWFCD+yBS4u1c=,iv:t3DNqqZbY/N5AzPfrd1YNXhq4aQHoKuV1gqrK8rz1Iw=,tag:SOct9FcLV1h9ApoMPGFRfA==,type:comment]
     #
-    #ENC[AES256_GCM,data:FgeToHca3HqT2NxCdcRo9HZFyr/LZE+Lp6VtwqzoPIyDoA==,iv:heAU6F7jAzGWecZp/wx8wBH+TKPUttXAA2PkLzSSjRQ=,tag:l81UrFvJicKr3gZGi9kmRg==,type:comment]
-    #ENC[AES256_GCM,data:577vJypt3fdsmFFEe6vlFuUbu/RauEMTnPN4cKGaYwcJlMCGo0/90G+0JwFGD7eK1A0=,iv:tQKqIqtymkz5uvQs7+W1LU1A3EMEIXybBgTb0FsJ0Zg=,tag:YKvVT7mNcEsif6y5wcRKzg==,type:comment]
-    auth: ENC[AES256_GCM,data:O17C0+ZcUdRRXh55omHYOtDK1CMh8h/7k/n/7h/8wrb1sDADA8VVXIgTisZV,iv:g0zSIrL3WwjF3WjdmDdcSio7DCS6dIggEQotpmE0InI=,tag:1SX0+sHEUh0sVV9zD1Anqw==,type:str]
+    #ENC[AES256_GCM,data:uBN60G1jQ1OxdEr+BAkgvkaScr8fdXRhorUKyCwaA8Mo9A==,iv:WhB973uJF2p2Rcy/F0LssZzMxgJjgoW+fG/7WbdHtZA=,tag:PvUfNQcRbNfRppTAe6EQwg==,type:comment]
+    #ENC[AES256_GCM,data:Gk2+mqtJQfUC3EgQCDw3Fgxo9QIa+SZg7DhHWiWdr3IadRkSmHr4s45TL96SKTmB3LQ=,iv:noPglgfC+wItF8uvLB5oT3bbK+ajSz6gH8bRIyK/zI0=,tag:u10K7emhJ5eYeAb+a6w6CQ==,type:comment]
+    auth: ENC[AES256_GCM,data:DUHCqLsyLI5f/xnUUF6CkeZn7pJOnIsgFwWJrXu4mFD72nfajL+Z879tb4Kz,iv:WibJQqWs/uYfX13irP/o0iwuqQnYkd0Cpwo9ChgSdqs=,tag:De+SLflx54S/RTRwVFF64w==,type:str]
 kind: Secret
 metadata:
     labels:
@@ -19,16 +19,16 @@ metadata:
 type: Opaque
 sops:
     kms:
-        - arn: arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/autoretrieve
-          created_at: "2023-03-03T14:10:23Z"
-          enc: AQICAHgZ4zxFMLYL2iEHWJJh7edGwSAfx3nqUsNmImHieESc3QGZ0b9NkSxcPuRcHtsE7f0oAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM3CDDIUiMwEKLZCVqAgEQgDv1uDY0sHl3MR5hkPxzJgOHUNJR7+IL2yVrvs05tzGR77LrU3cm7+aMO39mBL3EhV/EP3s5g9lDFtUhgA==
+        - arn: arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/tornado
+          created_at: "2023-07-04T11:02:52Z"
+          enc: AQICAHjJQU/Sdz74Ynq5fzh11CEP0864D2mJ7Yvyc+gbZnpX+gHmmlrzz/TGAVFdjjcZFlJWAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMygRr3fkBvGNSfXkXAgEQgDur4Q5d0IB8tnFUMjJfJrW/W/NKyecJv+dydP5TF808Mdf/zIfUNZzlAnb+K+LUxG/HCb+5h8YQSyfnIw==
           aws_profile: ""
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-03-03T14:10:24Z"
-    mac: ENC[AES256_GCM,data:IvcW5kPrVjNXjwf2OYPtIFqPdjbuXzbporRqJmM6kQqZVEGhXfBuDrDNBA+TkpeM0S0BO8XRF4V+tvgbKQe60wUpMlDLi6PwvFJ6UzHAH+DpMFkYSadTE4jCSVOtxZS2H9U19rxPsot/lTbyBK0CcVy4d4A7Tai7/8YUA5QAqnE=,iv:C1+R6MVGUX+WmQW5ocUEAAYcG6aCS8A/FDTFH6C9xbU=,tag:Ea9WtcMWd48vI2bAN8NkcQ==,type:str]
+    lastmodified: "2023-07-04T11:02:52Z"
+    mac: ENC[AES256_GCM,data:77xTn3KxXkwJtAEV6mSC8asZLPWVgtovzX+JUFRjUNasZXm56M/ljk/5E+9VdvsFDWH6fWOeav8YDLmbcEZwZd8bhPcZLi3/rOeBmry6Wa+FZN4KBItQz6JsDkxmfkEI5U2THHKHjyBFBiDo5n2lVnZgarrzjq3U4XM3lUqRhsI=,iv:055OSyL2VJfDi654pc+1G1XmOentp7AbEdbxOflAW9o=,tag:FlejhjEuKURFQ3yP6DeyMw==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.7.3

--- a/deploy/manifests/dev/us-east-2/lassie-event-recorder/db-dsn-secret.yaml
+++ b/deploy/manifests/dev/us-east-2/lassie-event-recorder/db-dsn-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 stringData:
-    dsn: ENC[AES256_GCM,data:7T0M5lp3It0wNQCY7kuoTEMpwgcbJIT67S4hfzWRvd5P+9IDN/+IENcR3sR2XdlO+Ybu22GYqvVY60RESz5odQa2q+grOruvbZCXS1wFyuA7FCZ85AfrpxLMhjr4GcpN7j35b7J005vYavpToWMI4kfLE9GQfJzJgaI4ome4,iv:qkts6EsrCr3OKDU2Lgjc/JNlhnHmfkTnqjt0PI/TGfI=,tag:27n0QnqyX0VJRu+WLPkjWA==,type:str]
+    dsn: ENC[AES256_GCM,data:wDxf2/h4IGGeZqb9DRER30HcE6y60bRzGJakq/c50GaLSGlGxa7NgR7bDyMQtOGMC3LK+g5szVSf2i+HKckwpptwrhEZQLzi1sNRkU8Yfrj7v16glY8CphAl408T2+WHqGD4ESTZdcodow+XhJo9HNgVDFAzQKNuugKb8Hwb,iv:uRLfqWt1MQsdb/qgnl3QRDMlfPwD519MLEd6rMRI1T4=,tag:GFjE0qNzYCOC0vB50BzW1w==,type:str]
 kind: Secret
 metadata:
     labels:
@@ -9,16 +9,16 @@ metadata:
 type: Opaque
 sops:
     kms:
-        - arn: arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/autoretrieve
-          created_at: "2023-03-03T00:14:47Z"
-          enc: AQICAHgZ4zxFMLYL2iEHWJJh7edGwSAfx3nqUsNmImHieESc3QEfyNv4ByTgh691kiA5NSRoAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM0HBHs0WVYig1b80sAgEQgDtA0SkmgbpfQnX4nMBr5Aphu5M6n0jgBfWyOeCaHPlUS4kQv+VP53cx28vS5niOu5R6l1cuHQf3fKnP7w==
+        - arn: arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/tornado
+          created_at: "2023-07-04T11:03:02Z"
+          enc: AQICAHjJQU/Sdz74Ynq5fzh11CEP0864D2mJ7Yvyc+gbZnpX+gH5xbtG9wog3vqF5904DrbwAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMc6Wfzc5v2nsVYgKgAgEQgDusU6l6b/As9BVaV1YleRJEZxJvVdl03HOB4oyugprW369MaFkB9n7yn9y5qUwBancFQ/AUv5B8GHS5BA==
           aws_profile: ""
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-03-03T00:14:48Z"
-    mac: ENC[AES256_GCM,data:Y1ktQgoPgcc38gxt9NeVwkt3OaFYJkThkG1m+CkkjZ1UMGGHjg/4QFEHBBrtj3Xx/Pkp8h+L4a2LdNJAhNncTeWmAYNF9EZEVDmRQimaMA/05aC6hkKEfTmvE3+e7KSfkUNbz4QffVOECRC0xmd/k3jMvX/wLMFQX3lX9a5RZhE=,iv:d1UgyegLML0ZwCYtk922N/fUhZ12GdzygtPPoMe6jH4=,tag:H+Wd9Fn9UkCPpIhKiL4ntA==,type:str]
+    lastmodified: "2023-07-04T11:03:02Z"
+    mac: ENC[AES256_GCM,data:pBPJh9Ov3xNrKhxP29VtIPoolg68BPWkzGUHWSJjqgjj5cmWCOV8grxJ6r+3yKk+VHNNiuT/eUkRUeFmegZVa5L9K/q4/38NaPQeXV3zU1fTr7moJvbsW5zuXn1U9tPK1Fm02nAZLEZxaDQ/FKFdVOU2Lap7PLwyil/BuasAhUY=,iv:3yzWWssF+ehByDRwWwmpXh3IY/dPsCtj+yTQUPqX1ak=,tag:NexQ6ZtnfrEcX0zm1/J/Mw==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.7.3

--- a/deploy/manifests/dev/us-east-2/lassie-event-recorder/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/lassie-event-recorder/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: autoretrieve
+namespace: tornado
 
 resources:
   - ../../../base/lassie-event-recorder

--- a/deploy/manifests/dev/us-east-2/lassie-event-recorder/mongo-secret.yaml
+++ b/deploy/manifests/dev/us-east-2/lassie-event-recorder/mongo-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 stringData:
-    mongoaddr: ENC[AES256_GCM,data:pJsFHu1k7f0TLJSbobYDsqEZqy7S691HFqwt+1WX8gD1gzYdU8XP+c0S4VOqbpSfakdyruDUqzpXrVLFBAUl/YhlXgyUR/PYlYN8YOZllhwneOM8dnn2prxNoYZ7YYCbkzDeZSjj01kBM7gX,iv:vWCbBps26Ao8Y5vbB4ss+d14Dy+QaXH0I71h27EoZRw=,tag:Xwjo/ugVr5mcPBRXV7N35w==,type:str]
+    mongoaddr: ENC[AES256_GCM,data:vnMnLe6MTtHyqZHgEBZOPZJimWJjOsGSaLOEYQJiTr4oG51e2aSIJJ6Vg2oB/AudY4ZcmXYVBweFiuG39NxCxrkwg94tFjEhGw53HwpzyzEY7zvE/ozyxxCvXG6zlZZr/XpvvULwPygcfVF+,iv:HpsOGhvJJAHeV4GDsSudmNw0GqJT+px/eDmIPCIJUiA=,tag:ukc31YsaryFwDPqQW/jO6A==,type:str]
 kind: Secret
 metadata:
     labels:
@@ -9,16 +9,16 @@ metadata:
 type: Opaque
 sops:
     kms:
-        - arn: arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/autoretrieve
-          created_at: "2023-05-15T22:08:45Z"
-          enc: AQICAHgZ4zxFMLYL2iEHWJJh7edGwSAfx3nqUsNmImHieESc3QF5OOx1+/u9ZX3Q+fyxIIoBAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM3fYWP0YFYuHFlO2YAgEQgDvYsitcfF5goWIAkNcyKdN9HfFw1g9E0UKkRkriaWl9g4iY8uUU+iFHZQCrugTqMwViA8Xp4psDfeKdPg==
+        - arn: arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/tornado
+          created_at: "2023-07-04T11:03:07Z"
+          enc: AQICAHjJQU/Sdz74Ynq5fzh11CEP0864D2mJ7Yvyc+gbZnpX+gFeCppy98I39NPLeWG1MMQ5AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMsOO1nZjVKZujs2LnAgEQgDskcmRIBCzhTE1VENzLmS8tn9TNlqH4PoOnW0VkrS6nj2T6n31/wEzNwtbWbqvyIVpsr3Vu2EaQ+HmPRg==
           aws_profile: ""
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-05-15T22:08:45Z"
-    mac: ENC[AES256_GCM,data:+SHAg/2T59xRQ5rEKcHLciasXhnf1Mqig9r+WAZVwMeNTtCFUT2FDUnanYcvMy+GJebQ4GtaQtNW3JDQZimn8uSO0C+MC+rEFAX4t7ylJY6ohgMxTb1fuLdVGVwjJuQMkkEjaykVg/KFH9LylPJXF+0sdeFWHwrD8ZPFrMx0p+Q=,iv:6ajpFojLmrGFp8Iu9rRXUHYEhxWO5jFnqfENXyg8La0=,tag:gl/M7jXKWcd8RhujZM035g==,type:str]
+    lastmodified: "2023-07-04T11:03:07Z"
+    mac: ENC[AES256_GCM,data:lc/b0epbYABEE/UF3BfbyJEH/c1kVn7LlaA3VYiCmfqXkJcFaW4PZbFMGw9TD5f62/U2dV/OSQAMCkGUWsh9SOq7W/iuYDRm66IW/dO3UTY9RpSjo25EoLouXFM3A6zPXSkSXbN7hg+wKZ7VfI8nfTjQZbEUDMDWleG/urb8cnE=,iv:JSqGVmPWrCO2kxUeFwF9LKYzRFPZKLgBGaHayNiBG5I=,tag:BknzIQi8hi5R12orZ3HkEQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.7.3

--- a/deploy/manifests/dev/us-east-2/lassie-event-recorder/monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/lassie-event-recorder/monitor.yaml
@@ -10,7 +10,7 @@ spec:
       app: lassie-event-recorder
   namespaceSelector:
     matchNames:
-      - autoretrieve
+      - tornado
   podMetricsEndpoints:
     - path: /metrics
       port: admin


### PR DESCRIPTION
Autoretrieve is no longer, so we should rename namespace to tornado.