### PR TITLE
fix: use a new hostname

### DIFF
--- a/deploy/manifests/dev/us-east-2/lassie-event-recorder/ingress.yaml
+++ b/deploy/manifests/dev/us-east-2/lassie-event-recorder/ingress.yaml
@@ -11,10 +11,10 @@ metadata:
 spec:
   tls:
     - hosts:
-        - lassie-event-recorder.dev.cid.contact
+        - lassie-event-recorder-2.dev.cid.contact
       secretName: lassie-event-recorder-ingress-tls
   rules:
-    - host: lassie-event-recorder.dev.cid.contact
+    - host: lassie-event-recorder-2.dev.cid.contact
       http:
         paths:
           - path: /


### PR DESCRIPTION
Whoops, uses the same hostname as the autoretrieve namespace. They need to be different so that they don't collide.