### PR TITLE
Revert "fix: use a new hostname"

### DIFF
--- a/deploy/manifests/dev/us-east-2/lassie-event-recorder/ingress.yaml
+++ b/deploy/manifests/dev/us-east-2/lassie-event-recorder/ingress.yaml
@@ -11,10 +11,10 @@ metadata:
 spec:
   tls:
     - hosts:
-        - lassie-event-recorder-2.dev.cid.contact
+        - lassie-event-recorder.dev.cid.contact
       secretName: lassie-event-recorder-ingress-tls
   rules:
-    - host: lassie-event-recorder-2.dev.cid.contact
+    - host: lassie-event-recorder.dev.cid.contact
       http:
         paths:
           - path: /


### PR DESCRIPTION
Reverts filecoin-project/tornado-deploy#84

Now that both services are operational, we manually remove the old ingress, which means the ingress in this repo should be the one hit by Saturn nodes. Therefore, reverting #84.